### PR TITLE
Fix error when binaries are not in /sbin

### DIFF
--- a/evillimiter/common/globals.py
+++ b/evillimiter/common/globals.py
@@ -1,11 +1,9 @@
-import os
+import evillimiter.console.shell as shell
 
-
-DEVNULL = open(os.devnull, 'w')
 BROADCAST = 'ff:ff:ff:ff:ff:ff'
 
-BIN_TC = '/sbin/tc'
-BIN_IPTABLES = '/sbin/iptables'
-BIN_SYSCTL = '/sbin/sysctl'
+BIN_TC = shell.locate_bin('tc')
+BIN_IPTABLES = shell.locate_bin('iptables')
+BIN_SYSCTL = shell.locate_bin('sysctl')
 
 IP_FORWARD_LOC = 'net.ipv4.ip_forward'

--- a/evillimiter/console/shell.py
+++ b/evillimiter/console/shell.py
@@ -1,6 +1,8 @@
+import os
 import subprocess
+from evillimiter.console.io import IO
 
-from evillimiter.common.globals import DEVNULL
+DEVNULL = open(os.devnull, 'w')
 
 
 def execute(command, root=True):
@@ -9,3 +11,18 @@ def execute(command, root=True):
 
 def execute_suppressed(command, root=True):
     return subprocess.call('sudo ' + command if root else command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+
+
+def output(command, root=True):
+    return subprocess.check_output('sudo ' + command if root else command, shell=True).decode('utf-8')
+
+
+def output_suppressed(command, root=True):
+    return subprocess.check_output('sudo ' + command if root else command, shell=True, stderr=DEVNULL).decode('utf-8')
+
+
+def locate_bin(name):
+    try:
+        return output_suppressed('which {}'.format(name)).replace('\n', '')
+    except subprocess.CalledProcessError:
+        IO.error('missing util: {}, check your PATH'.format(name))


### PR DESCRIPTION
Not all distros put the required binaries in `/sbin`, leading to errors. This patch uses `which` to look for the binaries, and tells the user if it couldn't be found.