### PR TITLE
networking: scan.py remove dead imports

### DIFF
--- a/evillimiter/networking/scan.py
+++ b/evillimiter/networking/scan.py
@@ -1,7 +1,5 @@
-import sys
 import socket
 from tqdm import tqdm
-from netaddr import IPAddress
 from scapy.all import sr1, ARP # pylint: disable=no-name-in-module
 from concurrent.futures import ThreadPoolExecutor
 


### PR DESCRIPTION
Both sys and IPAddress seems to not be of any use in scan.