### PR TITLE
Enforce the same end of line with gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.py text


### PR DESCRIPTION
Noticed after working on f4ab28eb1b0d506c614037a58bbcffde53c995ef that some of the files got changed due to the end of line.

this will enforce the same end of line for all python files.