### PR TITLE
Added support to OS (kali linux for example) that using iptables nf_tables

### DIFF
--- a/evillimiter/common/globals.py
+++ b/evillimiter/common/globals.py
@@ -3,7 +3,7 @@ import evillimiter.console.shell as shell
 BROADCAST = 'ff:ff:ff:ff:ff:ff'
 
 BIN_TC = shell.locate_bin('tc')
-BIN_IPTABLES = shell.locate_bin('iptables')
+BIN_IPTABLES = shell.locate_iptables_bin('iptables')
 BIN_SYSCTL = shell.locate_bin('sysctl')
 
 IP_FORWARD_LOC = 'net.ipv4.ip_forward'

--- a/evillimiter/console/shell.py
+++ b/evillimiter/console/shell.py
@@ -21,6 +21,11 @@ def output_suppressed(command, root=True):
     return subprocess.check_output('sudo ' + command if root else command, shell=True, stderr=DEVNULL).decode('utf-8')
 
 
+def locate_iptables_bin(name):
+    if "nf_tables" in output_suppressed("{} --version".format(name)):
+        return locate_bin("iptables-legacy")
+    return locate_bin(name)
+
 def locate_bin(name):
     try:
         return output_suppressed('which {}'.format(name)).replace('\n', '')


### PR DESCRIPTION
Hi, many S.O like kali linux is come from with iptables with support nf_tables by default, that is bad the top set iptables rules. For solve this, I put a patch to find the iptables version and if is with `nf_tables` support set the legacy iptables `iptables-legacy` version as default patch binary. 

the version legacy all rules write for old iptables willl be work fine. 

Thanks for all, mh4x0f 