### PR TITLE
Update README.md Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Possibly missing python packages will be installed during the installation proce
 ```bash
 git clone https://github.com/bitbrute/evillimiter.git
 cd evillimiter
+sudo apt install python3-setuptools
+sudo apt install python3-netifaces
 sudo python3 setup.py install
 ```
 


### PR DESCRIPTION
For Debian 13 and Ubuntu like 24.04 or newer, some Python3 libraries are required such as setuptools and netifaces