### PR TITLE
feat: networking: add ipv6 for limit and block functionality

### DIFF
--- a/evillimiter/common/globals.py
+++ b/evillimiter/common/globals.py
@@ -4,6 +4,7 @@ BROADCAST = 'ff:ff:ff:ff:ff:ff'
 
 BIN_TC = shell.locate_bin('tc')
 BIN_IPTABLES = shell.locate_bin('iptables')
+BIN_IP6TABLES = shell.locate_bin('ip6tables')
 BIN_SYSCTL = shell.locate_bin('sysctl')
 
 IP_FORWARD_LOC = 'net.ipv4.ip_forward'

--- a/evillimiter/networking/limit.py
+++ b/evillimiter/networking/limit.py
@@ -2,7 +2,7 @@ import threading
 
 import evillimiter.console.shell as shell
 from .host import Host
-from evillimiter.common.globals import BIN_TC, BIN_IPTABLES
+from evillimiter.common.globals import BIN_TC, BIN_IPTABLES, BIN_IP6TABLES
 
 
 class Limiter(object):
@@ -21,22 +21,35 @@ class Limiter(object):
         Limits the uload/dload traffic of a host
         to a specified rate
         """
-        host_ids = self._new_host_limit_ids(host, direction)
+        host_ids = self.new_host_limit_ids(host, direction)
+        iptables_cmd = BIN_IP6TABLES if self._is_ipv6(host.ip) else BIN_IPTABLES
 
         if (direction & Direction.OUTGOING) == Direction.OUTGOING:
             # add a class to the root qdisc with specified rate
-            shell.execute_suppressed('{} class add dev {} parent 1:0 classid 1:{} htb rate {r} burst {b}'.format(BIN_TC, self.interface, host_ids.upload_id, r=rate, b=rate * 1.1))
+            shell.execute_suppressed('{} class add dev {} parent 1:0 classid 1:{} htb rate {r} brust {b}'.format(
+                BIN_TC, self.interface, host_ids.upload_id, r=rate, b=rate * 1.1
+            ))
             # add a fw filter that filters packets marked with the corresponding ID
-            shell.execute_suppressed('{} filter add dev {} parent 1:0 protocol ip prio {id} handle {id} fw flowid 1:{id}'.format(BIN_TC, self.interface, id=host_ids.upload_id))
+            shell.execute_suppressed('{} filter add dev {} parent 1:0 protocol ip prio {id} handle {id} fw flowid 1:{id}'.format(
+                BIN_TC, self.interface, id=host_ids.upload_id
+            ))
             # marks outgoing packets 
-            shell.execute_suppressed('{} -t mangle -A POSTROUTING -s {} -j MARK --set-mark {}'.format(BIN_IPTABLES, host.ip, host_ids.upload_id))
+            shell.execute_suppressed('{} -t mangle -A POSTROUTING -s {} -j MARK --set-mark {}'.format(
+                iptables_cmd, host.ip, host_ids.upload_id
+            ))
         if (direction & Direction.INCOMING) == Direction.INCOMING:
             # add a class to the root qdisc with specified rate
-            shell.execute_suppressed('{} class add dev {} parent 1:0 classid 1:{} htb rate {r} burst {b}'.format(BIN_TC, self.interface, host_ids.download_id, r=rate, b=rate * 1.1))
+            shell.execute_suppressed('{} class add dev {} parent 1:0 classid 1:{} htb rate {r} burst {b}'.format(
+                BIN_TC, self.interface, host_ids.download_id, r=rate, b=rate * 1.1
+            ))
             # add a fw filter that filters packets marked with the corresponding ID
-            shell.execute_suppressed('{} filter add dev {} parent 1:0 protocol ip prio {id} handle {id} fw flowid 1:{id}'.format(BIN_TC, self.interface, id=host_ids.download_id))
+            shell.execute_suppressed('{} filter add dev {} parent 1:0 protocol ip prio {id} handle {id} fw flowid 1:{id}'.format(
+                BIN_TC, self.interface, id=host_ids.download_id
+            ))
             # marks incoming packets
-            shell.execute_suppressed('{} -t mangle -A PREROUTING -d {} -j MARK --set-mark {}'.format(BIN_IPTABLES, host.ip, host_ids.download_id))
+            shell.execute_suppressed('{} -t mangle -A PREROUTING -d {} -j MARK --set-mark {}'.format(
+                iptables_cmd, host.ip, host_ids.download_id
+            ))
 
         host.limited = True
 
@@ -44,14 +57,18 @@ class Limiter(object):
             self._host_dict[host] = { 'ids': host_ids, 'rate': rate, 'direction': direction }
 
     def block(self, host, direction):
+        """
+        Blocks the traffic of a host (IPv4 Ipv6)
+        """
         host_ids = self._new_host_limit_ids(host, direction)
+        iptables_cmd = BIN_IP6TABLES if self._is_ipv6(host.ip) else BIN_IPTABLES
 
         if (direction & Direction.OUTGOING) == Direction.OUTGOING:
             # drops forwarded packets with matching source
-            shell.execute_suppressed('{} -t filter -A FORWARD -s {} -j DROP'.format(BIN_IPTABLES, host.ip))
+            shell.execute_suppressed('{} -t filter -A FORWARD -s {} -j DROP'.format(iptables_cmd, host.ip))
         if (direction & Direction.INCOMING) == Direction.INCOMING:
             # drops forwarded packets with matching destination
-            shell.execute_suppressed('{} -t filter -A FORWARD -d {} -j DROP'.format(BIN_IPTABLES, host.ip))
+            shell.execute_suppressed('{} -t filter -A FORWARD -d {} -j DROP'.format(iptables_cmd, host.ip))
 
         host.blocked = True
 
@@ -64,13 +81,14 @@ class Limiter(object):
             
         with self._host_dict_lock:
             host_ids = self._host_dict[host]['ids']
+            iptables_cmd = BIN_IP6TABLES if self._is_ipv6(host.ip) else BIN_IPTABLES
 
             if (direction & Direction.OUTGOING) == Direction.OUTGOING:
                 self._delete_tc_class(host_ids.upload_id)
-                self._delete_iptables_entries(host, direction, host_ids.upload_id)
+                self._delete_iptables_entries(host, direction, host_ids.upload_id, iptables_cmd)
             if (direction & Direction.INCOMING) == Direction.INCOMING:
                 self._delete_tc_class(host_ids.download_id)
-                self._delete_iptables_entries(host, direction, host_ids.download_id)
+                self._delete_iptables_entries(host, direction, host_ids.download_id, iptables_cmd)
 
             del self._host_dict[host]
 
@@ -138,16 +156,16 @@ class Limiter(object):
         shell.execute_suppressed('{} filter del dev {} parent 1:0 prio {}'.format(BIN_TC, self.interface, id_))
         shell.execute_suppressed('{} class del dev {} parent 1:0 classid 1:{}'.format(BIN_TC, self.interface, id_))
 
-    def _delete_iptables_entries(self, host, direction, id_):
+    def _delete_iptables_entries(self, host, direction, id_, iptables_cmd):
         """
         Deletes iptables rules for a given ID (host)
         """
         if (direction & Direction.OUTGOING) == Direction.OUTGOING:
-            shell.execute_suppressed('{} -t mangle -D POSTROUTING -s {} -j MARK --set-mark {}'.format(BIN_IPTABLES, host.ip, id_))
-            shell.execute_suppressed('{} -t filter -D FORWARD -s {} -j DROP'.format(BIN_IPTABLES, host.ip))
+            shell.execute_suppressed('{} -t mangle -D POSTROUTING -s {} -j MARK --set-mark {}'.format(iptables_cmd, host.ip, id_))
+            shell.execute_suppressed('{} -t filter -D FORWARD -s {} -j DROP'.format(iptables_cmd, host.ip))
         if (direction & Direction.INCOMING) == Direction.INCOMING:
-            shell.execute_suppressed('{} -t mangle -D PREROUTING -d {} -j MARK --set-mark {}'.format(BIN_IPTABLES, host.ip, id_))
-            shell.execute_suppressed('{} -t filter -D FORWARD -d {} -j DROP'.format(BIN_IPTABLES, host.ip))
+            shell.execute_suppressed('{} -t mangle -D PREROUTING -d {} -j MARK --set-mark {}'.format(iptables_cmd, host.ip, id_))
+            shell.execute_suppressed('{} -t filter -D FORWARD -d {} -j DROP'.format(iptables_cmd, host.ip))
 
 
 class Direction:


### PR DESCRIPTION
- Implement dual-stack (IPv4/IPv6) support in Limiter class
- Add ip6tables rules for IPv6 traffic control
- Modify tc rules to work with both IPv4 and IPv6
- Add IPv6 detection helper method (_is_ipv6)