### PR TITLE
fix: resolve circular import and None hostname crash in monitor

### DIFF
--- a/evillimiter/console/io.py
+++ b/evillimiter/console/io.py
@@ -1,8 +1,6 @@
 import re
 import colorama
 
-from . import shell
-
 
 class IO(object):
     _ANSI_CSI_RE = re.compile('\001?\033\\[((?:\\d|;)*)([a-zA-Z])\002?') 
@@ -68,6 +66,7 @@ class IO(object):
         """
         Clears the terminal screen
         """
+        from evillimiter.console import shell
         shell.execute('clear')
 
     @staticmethod

--- a/evillimiter/menus/main_menu.py
+++ b/evillimiter/menus/main_menu.py
@@ -244,10 +244,10 @@ class MainMenu(CommandMenu):
                 IO.error('unable to resolve mac address. specify manually (--mac).')
                 return
 
-        name = None
+        name = ''
         try:
             host_info = socket.gethostbyaddr(ip)
-            name = None if host_info is None else host_info[0]
+            name = host_info[0]
         except socket.herror:
             pass
 


### PR DESCRIPTION
The bug:
1. Using the 'add' command to manually add a host by IP, then running 'monitor', crashes with:
2. io.py imports something from shell.py while shell.py also imports IO from io.py (Circular import)

TypeError: object of type 'NoneType' has no len()

the root cause:

In _add_handler, when socket.gethostbyaddr() raises socket.herror (hostname unresolvable ; common on local networks), name stays None and `Host(ip, mac, None)` is created. In `_monitor_handler`, `len(host.name)` is called to calculate column widths, which crashes on `None`.

In the process i also discovered the circular import mentioned.

The fix:
- menus/main_menu.py: default name = '' instead of  name = None, fixing the data contract at the source rather than patching every consumer.
- console/io.py: move `shell` import from module level into `IO.clear()` as a local import, breaking the circular dependency.
```